### PR TITLE
Is not quite correct naming: `alias t title`

### DIFF
--- a/lib/tophat/title.rb
+++ b/lib/tophat/title.rb
@@ -12,7 +12,6 @@ module TopHat
         display_tophat_title(title || options)
       end
     end
-    alias t title
 
     private
 


### PR DESCRIPTION
What is this naming not quite correct for?

I used your awesome gem for all my Rails applications since I'd found it. But, as you know, Rails also has a helper that has `t` name and there are many gems which use this helper too. So, while using Tophat with such gems, the conflict happens. Sure, there is a way just to use `I18n.t` in all this gems but I found more efficient way: to remove alias method from Tophat gem. 

If you find this right — merge and release, please! =)
