### PR TITLE
Do not override default description when custom description is blank

### DIFF
--- a/lib/tophat/meta.rb
+++ b/lib/tophat/meta.rb
@@ -28,7 +28,7 @@ module TopHat
       else
         default_description = options.delete(:default)
         options[:name] = 'description'
-        options[:content] = TopHat.current['description'] || default_description
+        options[:content] = TopHat.current['description'].blank? ? default_description : TopHat.current['description']
 
         meta_tag(options) if options[:content]
       end

--- a/lib/tophat/version.rb
+++ b/lib/tophat/version.rb
@@ -1,3 +1,3 @@
 module TopHat
-  VERSION = '2.2.1'
+  VERSION = '2.2.0'
 end

--- a/lib/tophat/version.rb
+++ b/lib/tophat/version.rb
@@ -1,3 +1,3 @@
 module TopHat
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end

--- a/spec/tophat/meta_helper_spec.rb
+++ b/spec/tophat/meta_helper_spec.rb
@@ -90,6 +90,11 @@ describe TopHat::MetaHelper do
       @template.description('This is a custom description')
       expect(@template.description(:default => 'This is a default description.')).to eq('<meta content="This is a custom description" name="description" />')
     end
+
+    it "uses the default description if custom description is blank" do
+      @template.description('')
+      expect(@template.description(:default => 'This is a default description')).to eq('<meta content="This is a default description" name="description" />')
+    end 
   end
 
   describe ".itemprop" do


### PR DESCRIPTION
Hi, 
In view files blank strings don't override default keywords however blank strings override description. I think It shouldn't override either.