### PR TITLE
Fix Rails 5 Deprecation

### DIFF
--- a/lib/tophat/reset.rb
+++ b/lib/tophat/reset.rb
@@ -2,7 +2,7 @@ module TopHat
   module Reset
 
     def self.included(base)
-      base.append_before_filter :reset_tophat
+      base.append_before_action :reset_tophat
     end
 
     def reset_tophat


### PR DESCRIPTION
```
DEPRECATION WARNING: append_before_filter is deprecated and will be removed in Rails 5.1. Use append_before_action instead. (called from included at /usr/src/app/vendor/bundle/ruby/2.3.0/gems/tophat-2.3.0/lib/tophat/reset.rb:5)
```
If you'd like to retain backwards compatibility with Rails < 4, you could do this instead.

```ruby
if Rails::VERSION::MAJOR >= 4
  base.append_before_action :reset_tophat
else
  base.append_before_filter :reset_tophat
end
```